### PR TITLE
adding exec function

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -24,10 +24,15 @@ var execCmd = &cobra.Command{
 	Short: "Execute a command with specified environment variables and arguments",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		// Call the Exec function from internal/exec package
-		_, err := exec.Run(executable, envVars, args, stream, fileOutputStream)
+		result, err := exec.Run(executable, envVars, args, stream, fileOutputStream)
 		if err != nil {
 			return fmt.Errorf("execution failed: %w", err)
 		}
+
+		// Print the results
+		fmt.Printf("StdOut:\n%s\n", result.StdOut)
+		fmt.Printf("StdErr:\n%s\n", result.StdErr)
+		fmt.Printf("ExitCode: %d\n", result.ExitCode)
 
 		return nil
 	},

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	executable string
-	envVars    map[string]string
-	args       []string
-	stream     bool
+	executable       string
+	envVars          map[string]string
+	args             []string
+	stream           bool
+	fileOutputStream string
 )
 
 // execCmd is the execute command for Cobra
@@ -23,7 +24,7 @@ var execCmd = &cobra.Command{
 	Short: "Execute a command with specified environment variables and arguments",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		// Call the Exec function from internal/exec package
-		result, err := exec.Run(executable, envVars, args, stream)
+		result, err := exec.Run(executable, envVars, args, stream, fileOutputStream)
 		if err != nil {
 			return fmt.Errorf("execution failed: %w", err)
 		}
@@ -44,6 +45,7 @@ func init() {
 	execCmd.Flags().StringToStringVarP(&envVars, "env", "v", nil, "Environment variables (key=value)")
 	execCmd.Flags().StringArrayVarP(&args, "args", "a", nil, "Arguments to pass to the executable")
 	execCmd.Flags().BoolVarP(&stream, "stream", "s", false, "Boolean to turn on stream from stdout")
+	execCmd.Flags().StringVarP(&fileOutputStream, "fileOutputStream", "o", "os.Stdout", "Destination file to io stream to. Defaults to stdout")
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/mja8020/templar/internal/exec"
+	"github.com/spf13/cobra"
+)
+
+var (
+	executable string
+	envVars    map[string]string
+	args       []string
+)
+
+// execCmd is the execute command for Cobra
+var execCmd = &cobra.Command{
+	Use:   "execute",
+	Short: "Execute a command with specified environment variables and arguments",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		// Call the Exec function from internal/exec package
+		result, err := exec.Run(executable, envVars, args)
+		if err != nil {
+			return fmt.Errorf("execution failed: %w", err)
+		}
+
+		// Print the results
+		fmt.Printf("StdOut:\n%s\n", result.StdOut)
+		fmt.Printf("StdErr:\n%s\n", result.StdErr)
+		fmt.Printf("ExitCode: %d\n", result.ExitCode)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(execCmd)
+
+	execCmd.Flags().StringVarP(&executable, "executable", "e", "/bin/bash", "Path to the executable")
+	execCmd.Flags().StringToStringVarP(&envVars, "env", "v", nil, "Environment variables (key=value)")
+	execCmd.Flags().StringArrayVarP(&args, "args", "a", nil, "Arguments to pass to the executable")
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// execCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// execCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -4,7 +4,9 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/mja8020/templar/internal/exec"
 	"github.com/spf13/cobra"
@@ -23,8 +25,12 @@ var execCmd = &cobra.Command{
 	Use:   "execute",
 	Short: "Execute a command with specified environment variables and arguments",
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		// Create a context with a timeout for the command
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
 		// Call the Exec function from internal/exec package
-		result, err := exec.Run(executable, envVars, args, stream, fileOutputStream)
+		result, err := exec.Run(ctx, executable, envVars, args, stream, fileOutputStream)
 		if err != nil {
 			return fmt.Errorf("execution failed: %w", err)
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -14,6 +14,7 @@ var (
 	executable string
 	envVars    map[string]string
 	args       []string
+	stream     bool
 )
 
 // execCmd is the execute command for Cobra
@@ -22,7 +23,7 @@ var execCmd = &cobra.Command{
 	Short: "Execute a command with specified environment variables and arguments",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		// Call the Exec function from internal/exec package
-		result, err := exec.Run(executable, envVars, args)
+		result, err := exec.Run(executable, envVars, args, stream)
 		if err != nil {
 			return fmt.Errorf("execution failed: %w", err)
 		}
@@ -42,6 +43,7 @@ func init() {
 	execCmd.Flags().StringVarP(&executable, "executable", "e", "/bin/bash", "Path to the executable")
 	execCmd.Flags().StringToStringVarP(&envVars, "env", "v", nil, "Environment variables (key=value)")
 	execCmd.Flags().StringArrayVarP(&args, "args", "a", nil, "Arguments to pass to the executable")
+	execCmd.Flags().BoolVarP(&stream, "stream", "s", false, "Boolean to turn on stream from stdout")
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -24,15 +24,10 @@ var execCmd = &cobra.Command{
 	Short: "Execute a command with specified environment variables and arguments",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		// Call the Exec function from internal/exec package
-		result, err := exec.Run(executable, envVars, args, stream, fileOutputStream)
+		_, err := exec.Run(executable, envVars, args, stream, fileOutputStream)
 		if err != nil {
 			return fmt.Errorf("execution failed: %w", err)
 		}
-
-		// Print the results
-		fmt.Printf("StdOut:\n%s\n", result.StdOut)
-		fmt.Printf("StdErr:\n%s\n", result.StdErr)
-		fmt.Printf("ExitCode: %d\n", result.ExitCode)
 
 		return nil
 	},

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.23.2
 replace github.com/hairyhenderson/gomplate/v4 v4.1.0 => github.com/mja8020/gomplate/v4 v4.0.0
 
 require (
+	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/hairyhenderson/gomplate/v4 v4.1.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
@@ -29,7 +30,6 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
-	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/Shopify/ejson v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ cuelabs.dev/go/oci/ociregistry v0.0.0-20240404174027-a39bec0462d2 h1:BnG6pr9TTr6
 cuelabs.dev/go/oci/ociregistry v0.0.0-20240404174027-a39bec0462d2/go.mod h1:pK23AUVXuNzzTpfMCA06sxZGeVQ/75FdVtW249de9Uo=
 cuelang.org/go v0.9.2 h1:pfNiry2PdRBr02G/aKm5k2vhzmqbAOoaB4WurmEbWvs=
 cuelang.org/go v0.9.2/go.mod h1:qpAYsLOf7gTM1YdEg6cxh553uZ4q9ZDWlPbtZr9q1Wk=
-dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
-dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0 h1:1nGuui+4POelzDwI7RG56yfQJHCnKvwfMoU7VsEp+Zg=
@@ -43,8 +41,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
-github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
 github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
@@ -161,6 +157,8 @@ github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsouza/fake-gcs-server v1.49.2 h1:fukDqzEQM50QkA0jAbl6cLqeDu3maQjwZBuys759TR4=
 github.com/fsouza/fake-gcs-server v1.49.2/go.mod h1:17SYzJEXRcaAA5ATwwvgBkSIqIy7r1icnGM0y/y4foY=
 github.com/gliderlabs/ssh v0.3.7 h1:iV3Bqi942d9huXnzEF2Mt+CY9gLu8DNM4Obd+8bODRE=

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -1,0 +1,117 @@
+package exec
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+type Execute struct {
+	StdOut   string
+	StdErr   string
+	ExitCode int
+}
+
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&0111 != 0 // Check for any executable bit
+}
+
+func Run(executable string, environment map[string]string, args []string) (Execute, error) {
+	var result Execute
+
+	execPath, err := exec.LookPath(executable)
+	if err != nil {
+		return result, fmt.Errorf("executable not found or not in PATH: %s", executable)
+	}
+	if !isExecutable(execPath) {
+		return result, fmt.Errorf("executable is not permitted to run: %s", execPath)
+	}
+
+	// Create the command
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("cmd", "/C", fmt.Sprintf("%s %s", execPath, strings.Join(args, " ")))
+	default: // Linux and macOS
+		cmd = exec.Command("/bin/bash", "-c", fmt.Sprintf("%s %s", execPath, strings.Join(args, " ")))
+	}
+
+	// Set up environment variables
+	env := os.Environ()
+	for key, value := range environment {
+		env = append(env, fmt.Sprintf("%s=%s", key, value))
+	}
+	cmd.Env = env
+
+	// Get stdout and stderr pipes
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		result.ExitCode = -1
+		return result, fmt.Errorf("failed to get stdout pipe: %v", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		result.ExitCode = -1
+		return result, fmt.Errorf("failed to get stderr pipe: %v", err)
+	}
+
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		result.ExitCode = -1 // Set a non-zero exit code on start failure
+		return result, fmt.Errorf("failed to start command: %v", err)
+	}
+
+	// Channel to signal when output collection is done
+	done := make(chan struct{})
+
+	// Stream stdout
+	go func() {
+		scanner := bufio.NewScanner(stdoutPipe)
+		for scanner.Scan() {
+			line := scanner.Text()
+			fmt.Println(line)            // Print each line to stdout
+			result.StdOut += line + "\n" // Collect stdout output
+		}
+		done <- struct{}{}
+	}()
+
+	// Stream stderr
+	go func() {
+		scanner := bufio.NewScanner(stderrPipe)
+		for scanner.Scan() {
+			line := scanner.Text()
+			fmt.Fprintln(os.Stderr, line) // Print each line to stderr
+			result.StdErr += line + "\n"  // Collect stderr output
+		}
+		done <- struct{}{}
+	}()
+
+	// Wait for the command to finish
+	if err := cmd.Wait(); err != nil {
+		// Capture the exit code if the command fails
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				result.ExitCode = status.ExitStatus()
+			}
+		} else {
+			result.ExitCode = -1
+		}
+		return result, err
+	}
+
+	result.ExitCode = 0
+
+	// Wait for both stdout and stderr to be fully collected
+	<-done
+	<-done
+
+	return result, nil
+}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"syscall"
 )
@@ -30,6 +29,7 @@ func isExecutable(path string) bool {
 func Run(executable string, environment map[string]string, args []string, stream bool, fileOutputStream string) (Execute, error) {
 	var result Execute
 
+	// Find execpath
 	execPath, err := exec.LookPath(executable)
 	if err != nil {
 		return result, fmt.Errorf("executable not found or not in PATH: %s", executable)
@@ -38,14 +38,8 @@ func Run(executable string, environment map[string]string, args []string, stream
 		return result, fmt.Errorf("executable is not permitted to run: %s", execPath)
 	}
 
-	// Create the command
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "windows":
-		cmd = exec.Command("cmd", "/C", fmt.Sprintf("%s %s", execPath, strings.Join(args, " ")))
-	default: // Linux and macOS
-		cmd = exec.Command("/bin/bash", "-c", fmt.Sprintf("%s %s", execPath, strings.Join(args, " ")))
-	}
+	// Set up command
+	cmd := exec.Command(execPath, strings.Join(args, " "))
 
 	// Set up environment variables
 	env := os.Environ()

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,0 +1,75 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExec_Success(t *testing.T) {
+	// Test a command that should succeed
+	executable := "/bin/bash"
+	environment := map[string]string{
+		"TEST_VAR": "Hello, World!",
+	}
+	args := []string{"-c", "echo $TEST_VAR"}
+
+	// Execute the command
+	result, err := Exec(executable, environment, args)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello, World!\n", result.StdOut)
+	assert.Equal(t, "", result.StdErr)
+	assert.Equal(t, 0, result.ExitCode)
+}
+
+func TestExec_CommandNotFound(t *testing.T) {
+	// Test a command that does not exist
+	executable := "/bin/doesnotexist"
+	environment := map[string]string{}
+	args := []string{}
+
+	// Execute the command
+	result, err := Exec(executable, environment, args)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start command")
+	assert.Equal(t, "", result.StdOut)
+	assert.Equal(t, "", result.StdErr)
+	assert.NotEqual(t, 0, result.ExitCode)
+}
+
+func TestExec_FailWithStdErr(t *testing.T) {
+	// Test a command that should fail and produce stderr output
+	executable := "/bin/bash"
+	environment := map[string]string{}
+	args := []string{"-c", "ls /nonexistent"}
+
+	// Execute the command
+	result, err := Exec(executable, environment, args)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Contains(t, result.StdErr, "No such file or directory")
+	assert.Equal(t, 2, result.ExitCode) // Expect exit code 2 for "no such file or directory"
+}
+
+func TestExec_WithEnvironmentVariables(t *testing.T) {
+	// Test a command that uses environment variables
+	executable := "/bin/bash"
+	environment := map[string]string{
+		"MY_VAR": "TestValue",
+	}
+	args := []string{"-c", "echo $MY_VAR"}
+
+	// Execute the command
+	result, err := Exec(executable, environment, args)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Equal(t, "TestValue\n", result.StdOut)
+	assert.Equal(t, "", result.StdErr)
+	assert.Equal(t, 0, result.ExitCode)
+}

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -78,5 +78,5 @@ func TestRunErrorOutput(t *testing.T) {
 
 	result, _ := Run(executable, env, args, stream, fileOutputStream)
 
-	assert.Contains(t, result.StdErr, "/usr/bin/ls: cannot access '/nonexistent_directory': No such file or directory", "unexpected stderr content")
+	assert.Contains(t, result.StdErr, "No such file or directory", "unexpected stderr content")
 }

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,28 +1,39 @@
 package exec
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRunSuccess(t *testing.T) {
-	// Define a simple executable command that should succeed
+	// Create a context with a timeout for the command
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Define the executable and arguments
 	executable := "echo"
 	args := []string{"Hello, world!"}
 	env := map[string]string{}
 	stream := false
 	fileOutputStream := "os.Stdout"
 
-	result, err := Run(executable, env, args, stream, fileOutputStream)
+	// Call the Run function with context
+	result, err := Run(ctx, executable, env, args, stream, fileOutputStream)
 	require.NoError(t, err, "expected no error during execution")
 	assert.Equal(t, 0, result.ExitCode, "expected exit code 0")
 	assert.Equal(t, "Hello, world!\n", result.StdOut, "unexpected stdout content")
 }
 
 func TestRunCommandNotFound(t *testing.T) {
+	// Create a context with a timeout for the command
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	// Use a non-existent command
 	executable := "nonexistentcommand"
 	args := []string{}
@@ -30,11 +41,15 @@ func TestRunCommandNotFound(t *testing.T) {
 	stream := false
 	fileOutputStream := "os.Stdout"
 
-	_, err := Run(executable, env, args, stream, fileOutputStream)
+	_, err := Run(ctx, executable, env, args, stream, fileOutputStream)
 	assert.Error(t, err, "expected error for non-existent command")
 }
 
 func TestRunPermissionDenied(t *testing.T) {
+	// Create a context with a timeout for the command
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	// Use an existing file that isn't executable
 	executable := "/etc/passwd" // A non-executable file on Unix systems
 	args := []string{}
@@ -42,11 +57,15 @@ func TestRunPermissionDenied(t *testing.T) {
 	stream := false
 	fileOutputStream := "os.Stdout"
 
-	_, err := Run(executable, env, args, stream, fileOutputStream)
+	_, err := Run(ctx, executable, env, args, stream, fileOutputStream)
 	assert.Error(t, err, "expected permission error for non-executable file")
 }
 
 func TestRunWithStreaming(t *testing.T) {
+	// Create a context with a timeout for the command
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	// Create a temporary file for streaming output
 	tmpFile, err := os.CreateTemp("", "output.txt")
 	require.NoError(t, err, "failed to create temp file")
@@ -59,7 +78,7 @@ func TestRunWithStreaming(t *testing.T) {
 	stream := true
 	fileOutputStream := tmpFile.Name()
 
-	result, err := Run(executable, env, args, stream, fileOutputStream)
+	result, err := Run(ctx, executable, env, args, stream, fileOutputStream)
 	require.NoError(t, err, "expected no error during execution")
 	assert.Equal(t, 0, result.ExitCode, "expected exit code 0")
 
@@ -70,13 +89,17 @@ func TestRunWithStreaming(t *testing.T) {
 }
 
 func TestRunErrorOutput(t *testing.T) {
+	// Create a context with a timeout for the command
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	executable := "ls"
 	args := []string{"/nonexistent_directory"}
 	env := map[string]string{}
 	stream := false
 	fileOutputStream := "os.Stdout"
 
-	result, _ := Run(executable, env, args, stream, fileOutputStream)
+	result, _ := Run(ctx, executable, env, args, stream, fileOutputStream)
 
 	assert.Contains(t, result.StdErr, "No such file or directory", "unexpected stderr content")
 }


### PR DESCRIPTION
Adding the exec function. Calls bash for darwin/linux and cmd for windows. can call run function directly for the cli for now, but likely change with a wrapper function to call extra functions with extra functionality i.e. parallel runs.