### PR TITLE
Allow selecting a path that isn't the current working directory

### DIFF
--- a/internal/tree/root.go
+++ b/internal/tree/root.go
@@ -6,26 +6,29 @@ import (
 	"path/filepath"
 )
 
-func getRootDirectory() (string, error) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("error getting current directory: %w", err)
+func getRootDirectory(starting string) (string, error) {
+	if starting == "" {
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("error getting current directory: %w", err)
+		}
+		starting = currentDir
 	}
 
 	for {
-		filePath := filepath.Join(currentDir, "templar.yaml")
+		filePath := filepath.Join(starting, "templar.yaml")
 
 		// Check if the file exists
 		if _, err := os.Stat(filePath); err == nil {
-			return currentDir, nil
+			return starting, nil
 		}
 
-		parentDir := filepath.Dir(currentDir)
-		if currentDir == parentDir {
+		parentDir := filepath.Dir(starting)
+		if starting == parentDir {
 			break
 		}
 
-		currentDir = parentDir
+		starting = parentDir
 	}
 
 	return "", fmt.Errorf("file 'templar.yaml' not found in any parent directories")

--- a/internal/tree/root_test.go
+++ b/internal/tree/root_test.go
@@ -77,7 +77,7 @@ func TestGetRootDirectory(t *testing.T) {
 			require.NoError(t, err)
 
 			// Call the function
-			result, err := getRootDirectory()
+			result, err := getRootDirectory("")
 
 			// Clean up by removing the templar.yaml file if it exists
 			for _, dir := range []string{nestedDir, filepath.Dir(nestedDir)} {

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -11,12 +11,17 @@ type Tree struct {
 
 // Generate a tree from the root of the project
 // Return pointer in case we need future mutablility
-func NewTree() (t *Tree, err error) {
+func NewTree(starting string) (t *Tree, err error) {
 	var paths []string
 
 	t = &Tree{}
 
-	path, err := getRootDirectory()
+	starting, err = filepath.Abs(starting)
+	if err != nil {
+		return
+	}
+
+	path, err := getRootDirectory(starting)
 	if err != nil {
 		return
 	}
@@ -42,7 +47,10 @@ func recursePath(path string, paths *[]string) (err error) {
 
 	for _, e := range entries {
 		if e.IsDir() {
-			recursePath(filepath.Join(path, e.Name()), paths)
+			err = recursePath(filepath.Join(path, e.Name()), paths)
+			if err != nil {
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
This will allow for the optional target `template --target=./some/other/path init` or any other commands

Fixed missing error check for recursePath